### PR TITLE
Moved `collective.iconifiedcategory` `ContentCategory` overrides back to `Products.PloneMeeting`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 0.17 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Moved `collective.iconifiedcategory` `ContentCategory` overrides
+  back to `Products.PloneMeeting`.
+  [gbastien]
 
 0.16 (2023-02-27)
 -----------------

--- a/src/imio/zamqp/pm/browser/configure.zcml
+++ b/src/imio/zamqp/pm/browser/configure.zcml
@@ -13,14 +13,12 @@
         for="Products.PloneMeeting.interfaces.IMeetingItem"
         name="document-generation"
         class=".overrides.AMQPPMDocumentGenerationView"
-        permission="zope2.View"
-        />
+        permission="zope2.View" />
 
     <browser:view
       for="imio.annex.content.annex.IAnnex"
       name="insert-barcode"
       class=".views.InsertBarcodeView"
-      permission="zope2.View"
-      />
+      permission="zope2.View" />
 
 </configure>

--- a/src/imio/zamqp/pm/configure.zcml
+++ b/src/imio/zamqp/pm/configure.zcml
@@ -12,18 +12,6 @@
     <include package="collective.zamqp" />
     <include package=".browser" />
 
-    <utility provides="plone.supermodel.parser.ISchemaPolicy"
-             name="category_zamqp_schema_policy"
-             factory=".overrides.CategoryZamqpSchemaPolicy" />
-
-    <utility provides="plone.supermodel.parser.ISchemaPolicy"
-             name="subcategory_zamqp_schema_policy"
-             factory=".overrides.SubcategoryZamqpSchemaPolicy" />
-
-    <utility provides="zope.schema.interfaces.IVocabularyFactory"
-             factory=".overrides.AfterScanChangeAnnexTypeToVocabulary"
-             name="imio.zamqp.pm.after_scan_change_annex_type_to_vocabulary" />
-    
     <utility component=".consumer.IconifiedAnnexConsumerUtility"
              name="dms.deliberation"
              provides="collective.zamqp.interfaces.IConsumer" />
@@ -41,13 +29,12 @@
                 handler=".events.onItemDuplicated"/>
 
     <include package="Products.GenericSetup" file="meta.zcml" />
-  
+
     <genericsetup:registerProfile
         name="default"
         title="PloneMeeting document scanning amqp"
         directory="profiles/default"
         description="Extension profile for PloneMeeting."
-        provides="Products.GenericSetup.interfaces.EXTENSION"
-        />
+        provides="Products.GenericSetup.interfaces.EXTENSION" />
 
 </configure>

--- a/src/imio/zamqp/pm/interfaces.py
+++ b/src/imio/zamqp/pm/interfaces.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-from collective.iconifiedcategory.content.category import ICategory
-from collective.iconifiedcategory.content.subcategory import ISubcategory
 from imio.zamqp.pm import _
 from zope import schema
 from zope.interface import Interface
@@ -9,25 +7,6 @@ from zope.interface import Interface
 
 class IIconifiedAnnex(Interface):
     """Marker interface for iconified annexes"""
-
-
-class IAnnexTypeZamqp(Interface):
-    """Specific fields when using zamqp"""
-
-    after_scan_change_annex_type_to = schema.Choice(
-        title=_(u'after_scan_change_annex_type_to_title'),
-        description=_(u"after_scan_change_annex_type_to_descr"),
-        vocabulary=u'imio.zamqp.pm.after_scan_change_annex_type_to_vocabulary',
-        required=False,
-    )
-
-
-class ICategoryZamqp(ICategory, IAnnexTypeZamqp):
-    """Specific fields when using zamqp"""
-
-
-class ISubcategoryZamqp(ISubcategory, IAnnexTypeZamqp):
-    """Specific fields when using zamqp"""
 
 
 class IImioZamqpPMSettings(Interface):

--- a/src/imio/zamqp/pm/locales/en/LC_MESSAGES/imio.zamqp.pm.po
+++ b/src/imio/zamqp/pm/locales/en/LC_MESSAGES/imio.zamqp.pm.po
@@ -34,14 +34,6 @@ msgstr "Value of x when inserting barcode into a PDF file."
 msgid "Value of y when inserting barcode into a PDF file."
 msgstr "Value of y when inserting barcode into a PDF file."
 
-#. Default: "When an annex using this annex type will be updated by the scan document automatic process, the annex type will be changed to the selected category.  If nothing is selected, the original annex type will remain"
-msgid "after_scan_change_annex_type_to_descr"
-msgstr ""
-
-#. Default: "New annex type when annex is update by the scan document process"
-msgid "after_scan_change_annex_type_to_title"
-msgstr ""
-
 #. Default: "Barcode already inserted!"
 msgid "barcode_already_inserted"
 msgstr "Barcode already inserted!"

--- a/src/imio/zamqp/pm/locales/fr/LC_MESSAGES/imio.zamqp.pm.po
+++ b/src/imio/zamqp/pm/locales/fr/LC_MESSAGES/imio.zamqp.pm.po
@@ -34,14 +34,6 @@ msgstr "Valeur du paramètre 'x' lors de l'insertion du code-barres dans un fich
 msgid "Value of y when inserting barcode into a PDF file."
 msgstr "Valeur du paramètre 'y' lors de l'insertion du code-barres dans un fichier PDF."
 
-#. Default: "When an annex using this annex type will be updated by the scan document automatic process, the annex type will be changed to the selected category.  If nothing is selected, the original annex type will remain"
-msgid "after_scan_change_annex_type_to_descr"
-msgstr "Lorsqu'une annexe qui utilise ce type d'annexe sera mise à jour par la procédure de scan de documents, le type d'annexe sera automatiquement changé vers celui sélectionné ici.  Si rien n'est sélectionné, le type d'annexe original sera gardé."
-
-#. Default: "New annex type when annex is update by the scan document process"
-msgid "after_scan_change_annex_type_to_title"
-msgstr "Nouveau type d'annexe à utiliser après mise à jour par la procédure de scan de documents"
-
 #. Default: "Barcode already inserted!"
 msgid "barcode_already_inserted"
 msgstr "Un code-barres a déjà été inséré dans ce fichier!"

--- a/src/imio/zamqp/pm/locales/imio.zamqp.pm.pot
+++ b/src/imio/zamqp/pm/locales/imio.zamqp.pm.pot
@@ -43,14 +43,6 @@ msgstr ""
 msgid "icon_help_barcode_inserted"
 msgstr ""
 
-#. Default: "New annex type when annex is update by the scan document process"
-msgid "after_scan_change_annex_type_to_title"
-msgstr ""
-
-#. Default: "When an annex using this annex type will be updated by the scan document automatic process, the annex type will be changed to the selected category.  If nothing is selected, the original annex type will remain"
-msgid "after_scan_change_annex_type_to_descr"
-msgstr ""
-
 #. Default: "Save a version of the annex when inserting the barcode."
 msgid "Save a version of the annex when inserting the barcode."
 msgstr ""

--- a/src/imio/zamqp/pm/overrides.py
+++ b/src/imio/zamqp/pm/overrides.py
@@ -1,19 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from collective.iconifiedcategory.content.category import CategorySchemaPolicy
-from collective.iconifiedcategory.content.categorygroup import ICategoryGroup
-from collective.iconifiedcategory.content.subcategory import SubcategorySchemaPolicy
-from imio.helpers.content import find
-from imio.zamqp.pm.interfaces import ICategoryZamqp
-from imio.zamqp.pm.interfaces import ISubcategoryZamqp
-from plone import api
-from Products.CMFPlone.utils import safe_unicode
 from Products.PloneMeeting.adapters import PMAnnexPrettyLinkAdapter
 from Products.PloneMeeting.config import BARCODE_INSERTED_ATTR_ID
 from zope.i18n import translate
-from zope.interface import implements
-from zope.schema.interfaces import IVocabularyFactory
-from zope.schema.vocabulary import SimpleVocabulary
 
 
 class IZPMAnnexPrettyLinkAdapter(PMAnnexPrettyLinkAdapter):
@@ -31,65 +20,3 @@ class IZPMAnnexPrettyLinkAdapter(PMAnnexPrettyLinkAdapter):
                                   domain="imio.zamqp.pm",
                                   context=self.request)))
         return res
-
-
-class AfterScanChangeAnnexTypeToVocabulary(object):
-    implements(IVocabularyFactory)
-
-    def __call__(self, context):
-        terms = []
-        if ICategoryGroup.providedBy(context):
-            category_group = context
-        else:
-            category_group = context.get_category_group()
-        category_groups = [category_group]
-        # for annexes added to item, it can be turned to an item_annex or
-        # an item_decision_annex and the other way round
-        if category_group.getId() == 'item_annexes':
-            category_groups.append(category_group.aq_parent.get('item_decision_annexes'))
-        elif category_group.getId() == 'item_decision_annexes':
-            category_groups.append(category_group.aq_parent.get('item_annexes'))
-
-        for cat_group in category_groups:
-            category_group_title = cat_group.Title()
-            categories = cat_group.objectValues()
-
-            for category in categories:
-                category_uid = category.UID()
-                # display content_category_group title in the term title
-                category_title = u'{0} → {1}'.format(
-                    safe_unicode(category_group_title),
-                    safe_unicode(category.Title()))
-                terms.append(SimpleVocabulary.createTerm(
-                    category_uid,
-                    category_uid,
-                    category_title,
-                ))
-                subcategories = find(
-                    context=category,
-                    object_provides='collective.iconifiedcategory.content.subcategory.ISubcategory',
-                    enabled=True,
-                    unrestricted=True
-                )
-                for subcategory in subcategories:
-                    subcategory_uid = subcategory.UID
-                    terms.append(SimpleVocabulary.createTerm(
-                        '{0}_{1}'.format(category_uid, subcategory_uid),
-                        '{0}_{1}'.format(category_uid, subcategory_uid),
-                        u'{0} → {1}'.format(
-                            safe_unicode(category_title),
-                            safe_unicode(subcategory.Title)),
-                    ))
-        return SimpleVocabulary(terms)
-
-
-class CategoryZamqpSchemaPolicy(CategorySchemaPolicy):
-
-    def bases(self, schema_name, tree):
-        return (ICategoryZamqp, )
-
-
-class SubcategoryZamqpSchemaPolicy(SubcategorySchemaPolicy):
-
-    def bases(self, schema_name, tree):
-        return (ISubcategoryZamqp, )


### PR DESCRIPTION
See #MPMBRWP-17